### PR TITLE
Fix Analog Contrôleur

### DIFF
--- a/data/menus/savegames.lua
+++ b/data/menus/savegames.lua
@@ -1,6 +1,7 @@
 -- Savegame selection screen.
 
 local savegame_menu = {}
+local joy_avoid_repeat = {-2, -2}
 
 function savegame_menu:on_started()
 
@@ -103,19 +104,26 @@ end
 
 function savegame_menu:on_joypad_axis_moved(axis, state)
 
-  if axis % 2 == 0 then  -- Horizontal axis.
-    if state > 0 then
-      self:direction_pressed(0)
-    elseif state < 0 then
-      self:direction_pressed(4)
+    local handled = joy_avoid_repeat[axis % 2] == state
+    joy_avoid_repeat[axis % 2] = state
+
+    if not handled then
+        if axis % 2 == 0 then  -- Horizontal axis.
+            if state > 0 then
+                self:direction_pressed(0)
+            elseif state < 0 then
+                self:direction_pressed(4)
+            end
+        else  -- Vertical axis.
+            if state > 0 then
+                self:direction_pressed(6)
+            elseif state < 0 then
+                self:direction_pressed(2)
+            end
+        end
     end
-  else  -- Vertical axis.
-    if state > 0 then
-      self:direction_pressed(6)
-    elseif state < 0 then
-      self:direction_pressed(2)
-    end
-  end
+
+    return handled
 end
 
 function savegame_menu:on_joypad_hat_moved(hat, direction8)
@@ -129,12 +137,6 @@ function savegame_menu:direction_pressed(direction8)
 
   local handled = true
   if self.allow_cursor_move and not self.finished then
-
-    -- The cursor moves too much when using a joypad axis.
-    self.allow_cursor_move = false
-    sol.timer.start(self, 100, function()
-      self.allow_cursor_move = true
-    end)
 
     -- Phase-specific direction_pressed method.
     local method_name = "direction_pressed_phase_" .. self.phase


### PR DESCRIPTION
Fixe le souci des contrôleur analogiques qui se déplacent trop dans les menus
En supprimant les répétitions de touche.