### PR TITLE
Fix Analog Contrôleur

### DIFF
--- a/data/menus/pause.lua
+++ b/data/menus/pause.lua
@@ -4,7 +4,8 @@ return function(game)
   local map_builder = require("menus/pause_map")
   local quest_status_builder = require("menus/pause_quest_status")
   local options_builder = require("menus/pause_options")
-
+  local joy_avoid_repeat = {-2, -2}
+  
   function game:start_pause_menu()
 
     self.pause_submenus = {
@@ -35,4 +36,12 @@ return function(game)
     self:set_custom_command_effect("attack", nil)
   end
 
+  function game:on_joypad_axis_moved(axis, state)
+    
+    local handled = joy_avoid_repeat[axis % 2] == state
+    joy_avoid_repeat[axis % 2] = state
+        
+    return handled
+  end
+  
 end


### PR DESCRIPTION
Fixe le souci des contrôleur analogiques qui se déplacent trop dans les menus
En supprimant les répétitions de touche.