### PR TITLE
Fix joystick repetition in language menu

### DIFF
--- a/data/menus/language.lua
+++ b/data/menus/language.lua
@@ -2,6 +2,7 @@
 -- If a language is already set, we skip this menu.
 
 local language_menu = {}
+local last_joy_axis_move = { 0, 0 }
 
 function language_menu:on_started()
 
@@ -106,19 +107,27 @@ end
 
 function language_menu:on_joypad_axis_moved(axis, state)
 
-  if axis % 2 == 0 then  -- Horizontal axis.
-    if state > 0 then
-      self:direction_pressed(0)
-    elseif state < 0 then
-      self:direction_pressed(4)
-    end
-  else  -- Vertical axis.
-    if state > 0 then
-      self:direction_pressed(6)
-    elseif state < 0 then
-      self:direction_pressed(2)
+  -- Avoid move repetition
+  local handled = last_joy_axis_move[axis % 2] == state
+  last_joy_axis_move[axis % 2] = state
+
+  if not handled then
+    if axis % 2 == 0 then  -- Horizontal axis.
+      if state > 0 then
+        self:direction_pressed(0)
+      elseif state < 0 then
+        self:direction_pressed(4)
+      end
+    else  -- Vertical axis.
+      if state > 0 then
+        self:direction_pressed(6)
+      elseif state < 0 then
+        self:direction_pressed(2)
+      end
     end
   end
+
+  return handled
 end
 
 function language_menu:on_joypad_hat_moved(hat, direction8)

--- a/data/menus/pause.lua
+++ b/data/menus/pause.lua
@@ -4,7 +4,7 @@ return function(game)
   local map_builder = require("menus/pause_map")
   local quest_status_builder = require("menus/pause_quest_status")
   local options_builder = require("menus/pause_options")
-  local joy_avoid_repeat = {-2, -2}
+  local last_joy_axis_move = { 0, 0 }
   
   function game:start_pause_menu()
 
@@ -37,10 +37,11 @@ return function(game)
   end
 
   function game:on_joypad_axis_moved(axis, state)
-    
-    local handled = joy_avoid_repeat[axis % 2] == state
-    joy_avoid_repeat[axis % 2] = state
-        
+
+    -- Avoid move repetition
+    local handled = last_joy_axis_move[axis % 2] == state
+    last_joy_axis_move[axis % 2] = state
+
     return handled
   end
   

--- a/data/menus/savegames.lua
+++ b/data/menus/savegames.lua
@@ -1,7 +1,7 @@
 -- Savegame selection screen.
 
 local savegame_menu = {}
-local joy_avoid_repeat = {-2, -2}
+local last_joy_axis_move = { 0, 0 }
 
 function savegame_menu:on_started()
 
@@ -104,26 +104,27 @@ end
 
 function savegame_menu:on_joypad_axis_moved(axis, state)
 
-    local handled = joy_avoid_repeat[axis % 2] == state
-    joy_avoid_repeat[axis % 2] = state
+  -- Avoid move repetition
+  local handled = last_joy_axis_move[axis % 2] == state
+  last_joy_axis_move[axis % 2] = state
 
-    if not handled then
-        if axis % 2 == 0 then  -- Horizontal axis.
-            if state > 0 then
-                self:direction_pressed(0)
-            elseif state < 0 then
-                self:direction_pressed(4)
-            end
-        else  -- Vertical axis.
-            if state > 0 then
-                self:direction_pressed(6)
-            elseif state < 0 then
-                self:direction_pressed(2)
-            end
-        end
+  if not handled then
+    if axis % 2 == 0 then  -- Horizontal axis.
+      if state > 0 then
+        self:direction_pressed(0)
+      elseif state < 0 then
+        self:direction_pressed(4)
+      end
+    else  -- Vertical axis.
+      if state > 0 then
+        self:direction_pressed(6)
+      elseif state < 0 then
+        self:direction_pressed(2)
+      end
     end
+  end
 
-    return handled
+  return handled
 end
 
 function savegame_menu:on_joypad_hat_moved(hat, direction8)


### PR DESCRIPTION
Fix joystick repetition in language menu + cosmetic

It's not related (sorry about that, maybe I should have open an issue) but there is a little bug when Link is on his bed (solarus 1.6 dev branch).

![wronf_offset](https://user-images.githubusercontent.com/5362098/33174138-064b99e0-d057-11e7-92cd-89d170f1d398.png)

The blanket gets back at the right position when you get off the bed.